### PR TITLE
Use valid category in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,6 +4,6 @@ author=txithihausen
 maintainer=txithihausen
 sentence=An Arduino Suiss Army Knife
 paragraph=An Arduino Suiss Army Knife
-category=Arduino tools
+category=Other
 url=https://github.com/txithihausen/asak.git
 architectures=*


### PR DESCRIPTION
The previous `category` value caused the warning:
```
WARNING: Category 'Arduino tools' in library asak is not valid. Setting to 'Uncategorized'
```
List of valid category values:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format