### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -20,6 +20,6 @@ enableAllSegments	KEYWORD2
 disableAllSegments	KEYWORD2
 enableDP	KEYWORD2
 disableDP	KEYWORD2
-plotNumber KEYWORD2
-setValue KEYWORD2
+plotNumber	KEYWORD2
+setValue	KEYWORD2
 


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords